### PR TITLE
chore(lfs): remove LFS tracking rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,9 @@
-*.fbx filter=lfs diff=lfs merge=lfs
-*.blend filter=lfs diff=lfs merge=lfs
-*.png filter=lfs diff=lfs merge=lfs
-*.jpg filter=lfs diff=lfs merge=lfs
-*.tga filter=lfs diff=lfs merge=lfs
-*.wav filter=lfs diff=lfs merge=lfs
-*.mp3 filter=lfs diff=lfs merge=lfs
-*.mp4 filter=lfs diff=lfs merge=lfs
-*.psd filter=lfs diff=lfs merge=lfs
+*.fbx !text !filter !merge !diff
+*.blend !text !filter !merge !diff
+*.png !text !filter !merge !diff
+*.jpg !text !filter !merge !diff
+*.tga !text !filter !merge !diff
+*.wav !text !filter !merge !diff
+*.mp3 !text !filter !merge !diff
+*.mp4 !text !filter !merge !diff
+*.psd !text !filter !merge !diff


### PR DESCRIPTION
- LFS rules were removed because LFS was disabled in Org.
- Pointers were converted to actual files using git lfs Migrate Export.
- No files larger than 100MB were left behind.